### PR TITLE
Adding explicit correlation for subscription sets

### DIFF
--- a/draft-ietf-webpush-protocol.xml
+++ b/draft-ietf-webpush-protocol.xml
@@ -442,7 +442,7 @@ Location: https://push.example.net/s/i-nQ3A9Zm4kgSWg8_ZijVQ
       </t>
       <t>
         How a push service detects that requests come from the same user agent
-        is implementation-dependent and could use ambient information into
+        is implementation-dependent and could take ambient information into
         consideration, such as the TLS connection, source IP address and port.
         Implementers are reminded that using some heuristics can produce false
         positives and cause requests to be rejected incorrectly.

--- a/draft-ietf-webpush-protocol.xml
+++ b/draft-ietf-webpush-protocol.xml
@@ -415,7 +415,9 @@ Link: </set/4UXwi2Rd7jGS7gp5cuutF8ZldnEuvbOy>;
       </figure>
         <t>
           This gives the push service the option to create a subscription within
-          an existing subscription set.
+          an existing subscription set.  The push service returns the same
+          subscription set in the response, though it MAY use a new subscription
+          set if it is unable to reuse the provided one.
         </t>
       <figure>
         <artwork type="inline">
@@ -432,6 +434,19 @@ Location: https://push.example.net/s/i-nQ3A9Zm4kgSWg8_ZijVQ
 
 ]]></artwork>
       </figure>
+      <t>
+        A push service MAY reject a request if it contains an unknown or invalid
+        subscription set, or a request that does not include a subscription set.
+        An 429 status code can be used to indicate that too many requests to
+        create subscriptions sets were made.
+      </t>
+      <t>
+        How a push service detects that requests come from the same user agent
+        is implementation-dependent and could use ambient information into
+        consideration, such as the TLS connection, source IP address and port.
+        Implementers are reminded that using some heuristics can produce false
+        positives and cause requests to be rejected incorrectly.
+      </t>
       </section>
     </section>
     <section anchor="receipt_subscription"

--- a/draft-ietf-webpush-protocol.xml
+++ b/draft-ietf-webpush-protocol.xml
@@ -391,10 +391,17 @@ Location: https://push.example.net/s/LBhhw0OohO-Wl4Oi971UGsB7sdQGUibx
         <t>
           The aggregation of multiple subscriptions into a subscription set can
           represent a significant efficiency improvement for a push service.
-          For that reason, a user agent MUST indicate an existing subscription
-          set in a request to create a subscription unless it has no other
-          subscriptions.  The user agent does this by adding a subscription set
-          link relation to the request to create a subscription.
+          For that reason, if a subscription set is available, a user agent MUST
+          indicate an existing subscription set in a request to create a
+          subscription.  However, a user agent MAY omit the subscription set if
+          it is unable to receive push messages that are aggregated for the
+          lifetime of the subscription.  This might be necessary if the user
+          agent is forwarding requests from other clients.
+        </t>
+        <t>
+          The user agent adds a subscription set link relation to the request to
+          create a subscription.  This indicates which subscription set the
+          subscription is to be bound to.
         </t>
       <figure>
         <artwork type="inline">
@@ -425,12 +432,6 @@ Location: https://push.example.net/s/i-nQ3A9Zm4kgSWg8_ZijVQ
 
 ]]></artwork>
       </figure>
-        <t>
-          A user agent MAY omit the subscription set link relation if it is
-          unable to receive push messages that are aggregated together.  This
-          might happen if the user agent is forwarding requests from other
-          clients.
-        </t>
       </section>
     </section>
     <section anchor="receipt_subscription"

--- a/draft-ietf-webpush-protocol.xml
+++ b/draft-ietf-webpush-protocol.xml
@@ -335,7 +335,7 @@
       </t>
       <figure>
         <artwork type="inline"><![CDATA[
-POST /subscribe/ HTTP/1.1
+POST /subscribe HTTP/1.1
 Host: push.example.net
 
 ]]></artwork>
@@ -389,8 +389,47 @@ Location: https://push.example.net/s/LBhhw0OohO-Wl4Oi971UGsB7sdQGUibx
       </figure>
       <section anchor="set-correlate" title="Correlating Subscriptions">
         <t>
-          PENDING: Discuss how two different subscriptions are correlated based on
-          either authentication or connection
+          The aggregation of multiple subscriptions into a subscription set can
+          represent a significant efficiency improvement for a push service.
+          For that reason, a user agent MUST indicate an existing subscription
+          set in a request to create a subscription unless it has no other
+          subscriptions.  The user agent does this by adding a subscription set
+          link relation to the request to create a subscription.
+        </t>
+      <figure>
+        <artwork type="inline">
+  <![CDATA[
+POST /subscribe HTTP/1.1
+Host: push.example.net
+Link: </set/4UXwi2Rd7jGS7gp5cuutF8ZldnEuvbOy>;
+        rel="urn:ietf:params:push:set"
+
+]]></artwork>
+      </figure>
+        <t>
+          This gives the push service the option to create a subscription within
+          an existing subscription set.
+        </t>
+      <figure>
+        <artwork type="inline">
+  <![CDATA[
+HTTP/1.1 201 Created
+Date: Thu, 11 Dec 2014 23:56:52 GMT
+Link: </p/YBJNBIMwwA_Ag8EtD47J4A>;
+        rel="urn:ietf:params:push"
+Link: </receipts/xjTG79I3VuptNWS0DsFu4ihT97aE6UQJ>;
+        rel="urn:ietf:params:push:receipt"
+Link: </set/4UXwi2Rd7jGS7gp5cuutF8ZldnEuvbOy>;
+        rel="urn:ietf:params:push:set"
+Location: https://push.example.net/s/i-nQ3A9Zm4kgSWg8_ZijVQ
+
+]]></artwork>
+      </figure>
+        <t>
+          A user agent MAY omit the subscription set link relation if it is
+          unable to receive push messages that are aggregated together.  This
+          might happen if the user agent is forwarding requests from other
+          clients.
         </t>
       </section>
     </section>


### PR DESCRIPTION
This replaces the PENDING section on correlation.  I know that @brianraymor wanted to simply rely on ambient authority of some sort, but I think that this is the cleanest option.  It doesn't cost us anything significant either.
