### PR TITLE
Require that 404 is used to signal expiration

### DIFF
--- a/draft-ietf-webpush-protocol.xml
+++ b/draft-ietf-webpush-protocol.xml
@@ -1084,7 +1084,7 @@ HEADERS      [stream 82] +END_STREAM
             A push service MAY expire a subscription set at any time which MUST also
             expire all push message subscriptions in the set. If a user agent has an
             outstanding request to a push subscription set (<xref target="monitor-set"/>)
-            this can be signaled by returning a 400-series status code, such as 410 (Gone).
+            this can be signaled by returning a 404 (Not Found) status code.
           </t>
           <t>
             A user agent can request that a subscription set be removed by sending a DELETE


### PR DESCRIPTION
As suggested by @beverloo
