### PR TITLE
Removed UA scenarios and references to section 7.5

### DIFF
--- a/draft-ietf-webpush-protocol.xml
+++ b/draft-ietf-webpush-protocol.xml
@@ -380,9 +380,9 @@ Location: https://push.example.net/subscription/LBhhw0OohO-Wl4Oi971UG
         </t>
         <t>
           A user agent MAY omit the subscription set if it is unable to receive
-          push messages in an aggregated way for the lifetime of the
-          subscription. This might be necessary if the user agent is monitoring
-          subscriptions for other clients (see <xref target="sets-streams"/>).
+          push messages in an aggregated way for the lifetime of the subscription.
+          This might be necessary if the user agent is monitoring subscriptions on
+          behalf of other push message receivers.
         </t>
       <figure>
         <artwork type="inline">
@@ -508,11 +508,11 @@ Location: https://push.example.net/message/qDIYHNcfAIPP_5ITvURr-d6BGt
           server.
         </t>
         <t>
-         An application server MAY omit the receipt subscription if it is
-         unable to receive receipts in an aggregated way for the lifetime of
-         the receipt subscription. This might be necessary if the application
-         server is monitoring receipt subscriptions on the behalf of other
-         push message senders (see <xref target="sets-streams"/>).
+          An application server MAY omit the receipt subscription if it is
+          unable to receive receipts in an aggregated way for the lifetime of
+          the receipt subscription. This might be necessary if the application
+          server is monitoring receipt subscriptions on the behalf of other
+          push message senders.
         </t>
         <t>
           A push service MUST return a 400 (Bad Request) status code for requests which contain
@@ -1143,12 +1143,6 @@ HEADERS      [stream 82] +END_STREAM
           subscriptions and one concurrent stream for each subscription set returned by the push service.
           This could force the user agent to serialize subscription requests to the push
           service.
-        </t>
-        <t>
-         A user agent that monitors subscriptions for other clients might
-         require multiple subscription sets. Each subscription set can then be
-         managed independently, which might include being moved between user
-         agents.
         </t>
       </section>
     </section>


### PR DESCRIPTION
I ensured that the "proxy" text in UA and AS were similar. I removed the cross-references to and added text in Section 7.5, which is specific to PS policies if it doesn't want to support multiple subscription sets. 

I did not call out potential UA scenarios in detail other than "monitoring on behalf" of other receivers or senders. WebPush provides a **mechanism** to enable proxies - but it may be better to have separate drafts that describe specific **policies** that use this mechanism to support scenarios such as moving between UA(s).
